### PR TITLE
Add USPTO API redirect support

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -58,7 +58,11 @@ internals.getZeroes = function(zeroes) {
 
 internals.getUrlHtml = function(url) {
 
-    return Wreck.requestAsync('GET', url, null).then(function(response) {
+    var options = {
+        redirects: 3
+    }
+
+    return Wreck.requestAsync('GET', url, options).then(function(response) {
 
         return Wreck.readAsync(response, null);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uspto",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "API for retrieving USPTO patent grants",
   "repository": "git://github.com/hofan41/uspto",
   "main": "lib/index.js",


### PR DESCRIPTION
Hi,

Recently I've encountered an issue with the USPTO API. USPTO now use HTTPS and all HTTP requests receive 302 response code. So the library doesn't work at the moment as it does not follow the redirect.
I've added a few changes to allow the library to follow the redirect from HTTP to HTTPS. Please, review the changes and consider to merge them.

Thanks for the library, btw.